### PR TITLE
Fixed a small bug that caused  subscription failed

### DIFF
--- a/iOS/SampleApp.xcodeproj/project.pbxproj
+++ b/iOS/SampleApp.xcodeproj/project.pbxproj
@@ -33,7 +33,6 @@
 		64AD85861C6A513400B8596D /* AVCommunication.m in Sources */ = {isa = PBXBuildFile; fileRef = 64AD85841C6A513400B8596D /* AVCommunication.m */; };
 		64AD85871C6A513400B8596D /* AVCommunication.xib in Resources */ = {isa = PBXBuildFile; fileRef = 64AD85851C6A513400B8596D /* AVCommunication.xib */; };
 		64AD85881C6A552E00B8596D /* OpenTok.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 64F2D19A1C6996EB00DAB853 /* OpenTok.framework */; };
-		64AD859C1C6A578F00B8596D /* OpenTok.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 64AD859B1C6A578F00B8596D /* OpenTok.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7F52A84DB2148AC09A1C6BC4 /* libPods-SampleApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58BECABDE6A6B2E578675B28 /* libPods-SampleApp.a */; };
 /* End PBXBuildFile section */
 
@@ -84,7 +83,6 @@
 		64AD85831C6A513400B8596D /* AVCommunication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVCommunication.h; sourceTree = "<group>"; };
 		64AD85841C6A513400B8596D /* AVCommunication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVCommunication.m; sourceTree = "<group>"; };
 		64AD85851C6A513400B8596D /* AVCommunication.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AVCommunication.xib; sourceTree = "<group>"; };
-		64AD859B1C6A578F00B8596D /* OpenTok.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OpenTok.framework; sourceTree = "<group>"; };
 		64F2D19A1C6996EB00DAB853 /* OpenTok.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenTok.framework; path = "/Users/estebancordero/Documents/worksuff/tokbox/A:V Component/SampleApp/OpenTok.framework"; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
@@ -109,7 +107,6 @@
 				6405A5F81C696C9B00441745 /* Foundation.framework in Frameworks */,
 				6405A5FC1C696C9B00441745 /* OpenGLES.framework in Frameworks */,
 				64AD85881C6A552E00B8596D /* OpenTok.framework in Frameworks */,
-				64AD859C1C6A578F00B8596D /* OpenTok.framework in Frameworks */,
 				7F52A84DB2148AC09A1C6BC4 /* libPods-SampleApp.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -128,7 +125,6 @@
 		6405A5AA1C696BE600441745 = {
 			isa = PBXGroup;
 			children = (
-				64AD859B1C6A578F00B8596D /* OpenTok.framework */,
 				6405A5E41C696C9B00441745 /* AVFoundation.framework */,
 				6405A5E51C696C9B00441745 /* CoreGraphics.framework */,
 				6405A5E61C696C9B00441745 /* CoreMedia.framework */,

--- a/iOS/SampleApp/AVCommunication.m
+++ b/iOS/SampleApp/AVCommunication.m
@@ -49,7 +49,7 @@ bool subscribeToSelf;
   _session = [[OTSession alloc] initWithApiKey:self.configInfo[@"api"]
                                      sessionId:self.configInfo[@"sessionId"]
                                       delegate:self];
-  subscribeToSelf = self.configInfo[@"subscribeToSelf"];
+  subscribeToSelf = [self.configInfo[@"subscribeToSelf"] boolValue];
   [self makingBorder:_micHolder need_background_transparent:YES];
   [self makingBorder:_callHolder need_background_transparent:NO];
   [self makingBorder:_videoHolder need_background_transparent:YES];
@@ -100,7 +100,7 @@ bool subscribeToSelf;
   NSLog(@"session streamCreated (%@)", stream.streamId);
   // (if NO == subscribeToSelf): Begin subscribing to a stream we
   // have seen on the OpenTok session.
-  if (nil == _subscriber && !subscribeToSelf) {
+  if (!subscribeToSelf) {
     [self doSubscribe:stream];
   }
 }

--- a/iOS/SampleApp/AVCommunication.xib
+++ b/iOS/SampleApp/AVCommunication.xib
@@ -5,7 +5,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="Widget">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AVCommunication">
             <connections>
                 <outlet property="callHolder" destination="fh8-0j-QU9" id="cWd-uF-KEc"/>
                 <outlet property="connectingLabel" destination="a0z-WZ-e0w" id="6tl-lD-q2z"/>


### PR DESCRIPTION
- Bug fixed: `NSDictionary` retrieves `NSNumber` which will make the bool value `true` all the time. Change the checking condition since `_subscriber` is not instantiated that time which will result `if` branch will not be called.
- Minor change: 
  - remove `OpenTok.framework` from the project file
  - change to correct file owner of the `AVCommunication.xib`
