### PR TITLE
Hide OT logic inside the implementation file

### DIFF
--- a/one-to-one-sample-app/iOS/SampleApp/MainViewController.m
+++ b/one-to-one-sample-app/iOS/SampleApp/MainViewController.m
@@ -22,7 +22,6 @@
 - (IBAction)publisherCallButtonPressed:(UIButton *)sender {
     if (self.oneToOneCommunicator.isCallEnabled) {
         [self.mainView callHolderDisconnected];
-        self.oneToOneCommunicator.isCallEnabled = NO;
         [self.mainView showConnectingLabel];
         [self.oneToOneCommunicator connectWithHandler:^(OneToOneCommunicationSignal signal, NSError *error) {
             
@@ -34,7 +33,6 @@
     }
     else {
         [self.mainView callHolderConnected];
-        self.oneToOneCommunicator.isCallEnabled = YES;
         [self.oneToOneCommunicator disconnect];
         
         [self.mainView removePublisherView];
@@ -48,7 +46,7 @@
     
     switch (signal) {
         case OneToOneCommunicationSignalSessionDidConnect: {
-            [self.mainView addPublisherView:self.oneToOneCommunicator.publisher.view];
+            [self.mainView addPublisherView:self.oneToOneCommunicator.publisherView];
             break;
         }
         case OneToOneCommunicationSignalSessionDidDisconnect:{
@@ -72,7 +70,7 @@
             break;
         }
         case OneToOneCommunicationSignalSubscriberConnect:{
-            [self.mainView addSubscribeView:self.oneToOneCommunicator.subscriber.view];
+            [self.mainView addSubscribeView:self.oneToOneCommunicator.subscriberView];
             break;
         }
         case OneToOneCommunicationSignalSubscriberDidFail:{
@@ -85,18 +83,18 @@
         }
         case OneToOneCommunicationSignalSubscriberVideoEnabled:{
             [self.mainView hideErrorMessageLabel];
-            [self.mainView addSubscribeView:self.oneToOneCommunicator.subscriber.view];
+            [self.mainView addSubscribeView:self.oneToOneCommunicator.subscriberView];
             break;
         }
         case OneToOneCommunicationSignalSubscriberVideoDisableWarning:{
             [self.mainView addPlaceHolderToSubscriberView];
-            self.oneToOneCommunicator.subscriber.subscribeToVideo = NO;
+            self.oneToOneCommunicator.subscribeToVideo = NO;
             [self.mainView showErrorMessageLabelWithMessage:@"Network connection is unstable." dismissAfter:0.0];
             break;
         }
         case OneToOneCommunicationSignalSubscriberVideoDisableWarningLifted:{
             [self.mainView hideErrorMessageLabel];
-            [self.mainView addSubscribeView:self.oneToOneCommunicator.subscriber.view];
+            [self.mainView addSubscribeView:self.oneToOneCommunicator.subscriberView];
             break;
         }
             
@@ -110,13 +108,13 @@
  */
 - (IBAction)publisherAudioButtonPressed:(UIButton *)sender {
     
-    if(self.oneToOneCommunicator.publisher.publishAudio) {
+    if(self.oneToOneCommunicator.publishAudio) {
         [self.mainView publisherMicMuted];
     }
     else {
         [self.mainView publisherMicUnmuted];
     }
-    self.oneToOneCommunicator.publisher.publishAudio = !self.oneToOneCommunicator.publisher.publishAudio;
+    self.oneToOneCommunicator.publishAudio = !self.oneToOneCommunicator.publishAudio;
 }
 
 /**
@@ -124,29 +122,28 @@
  */
 - (IBAction)publisherVideoButtonPressed:(UIButton *)sender {
     
-    if (self.oneToOneCommunicator.publisher.publishVideo) {
+    if (self.oneToOneCommunicator.publishVideo) {
         [self.mainView publisherVideoDisconnected];
         [self.mainView removePublisherView];
         [self.mainView addPlaceHolderToPublisherView];
     }
     else {
         [self.mainView publisherVideoConnected];
-        [self.mainView addPublisherView:self.oneToOneCommunicator.publisher.view];
+        [self.mainView addPublisherView:self.oneToOneCommunicator.publisherView];
     }
     
-    self.oneToOneCommunicator.publisher.publishVideo = !self.oneToOneCommunicator.publisher.publishVideo;
+    self.oneToOneCommunicator.publishVideo = !self.oneToOneCommunicator.publishVideo;
 }
 
 /**
  * toggle the camera position (front camera) <=> (back camera)
  */
 - (IBAction)publisherCameraButtonPressed:(UIButton *)sender {
-    
-    if (self.oneToOneCommunicator.publisher.cameraPosition == AVCaptureDevicePositionBack) {
-        self.oneToOneCommunicator.publisher.cameraPosition = AVCaptureDevicePositionFront;
+    if (self.oneToOneCommunicator.cameraPosition == AVCaptureDevicePositionBack) {
+        self.oneToOneCommunicator.cameraPosition = AVCaptureDevicePositionFront;
     }
     else {
-        self.oneToOneCommunicator.publisher.cameraPosition = AVCaptureDevicePositionBack;
+        self.oneToOneCommunicator.cameraPosition = AVCaptureDevicePositionBack;
     }
 }
 
@@ -155,13 +152,13 @@
  */
 - (IBAction)subscriberVideoButtonPressed:(UIButton *)sender {
     
-    if (self.oneToOneCommunicator.subscriber.subscribeToVideo) {
+    if (self.oneToOneCommunicator.subscribeToVideo) {
         [self.mainView subscriberVideoDisconnected];
     }
     else {
         [self.mainView subscriberVideoConnected];
     }
-    self.oneToOneCommunicator.subscriber.subscribeToVideo = !self.oneToOneCommunicator.subscriber.subscribeToVideo;
+    self.oneToOneCommunicator.subscribeToVideo = !self.oneToOneCommunicator.subscribeToVideo;
 }
 
 /**
@@ -169,13 +166,13 @@
  */
 - (IBAction)subscriberAudioButtonPressed:(UIButton *)sender {
 
-    if (self.oneToOneCommunicator.subscriber.subscribeToAudio) {
+    if (self.oneToOneCommunicator.subscribeToAudio) {
         [self.mainView subscriberMicMuted];
     }
     else {
         [self.mainView subscriberMicUnmuted];
     }
-    self.oneToOneCommunicator.subscriber.subscribeToAudio = !self.oneToOneCommunicator.subscriber.subscribeToAudio;
+    self.oneToOneCommunicator.subscribeToAudio = !self.oneToOneCommunicator.subscribeToAudio;
 }
 
 /**

--- a/one-to-one-sample-app/iOS/SampleApp/OneToOneCommunicator.h
+++ b/one-to-one-sample-app/iOS/SampleApp/OneToOneCommunicator.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Opentok/OpenTok.h>
+#import <AVFoundation/AVFoundation.h>
 
 typedef NS_ENUM(NSUInteger, OneToOneCommunicationSignal) {
     OneToOneCommunicationSignalSessionDidConnect = 0,
@@ -28,10 +28,6 @@ typedef void (^OneToOneCommunicatorBlock)(OneToOneCommunicationSignal signal, NS
 
 @interface OneToOneCommunicator : NSObject
 
-@property (nonatomic) BOOL isCallEnabled;
-@property (readonly, nonatomic) OTSubscriber *subscriber;
-@property (readonly, nonatomic) OTPublisher *publisher;
-
 + (instancetype)oneToOneCommunicator;
 + (void)setOpenTokApiKey:(NSString *)apiKey
                sessionId:(NSString *)sessionId
@@ -40,5 +36,19 @@ typedef void (^OneToOneCommunicatorBlock)(OneToOneCommunicationSignal signal, NS
 
 - (void)connectWithHandler:(OneToOneCommunicatorBlock)handler;
 - (void)disconnect;
+
+// CALL
+@property (readonly, nonatomic) BOOL isCallEnabled;
+
+// SUBSCRIBER
+@property (readonly, nonatomic) UIView *subscriberView;
+@property (nonatomic) BOOL subscribeToAudio;
+@property (nonatomic) BOOL subscribeToVideo;
+
+// PUBLISHER
+@property (readonly, nonatomic) UIView *publisherView;
+@property (nonatomic) BOOL publishAudio;
+@property (nonatomic) BOOL publishVideo;
+@property (nonatomic) AVCaptureDevicePosition cameraPosition;
 
 @end

--- a/one-to-one-sample-app/iOS/SampleApp/OneToOneCommunicator.m
+++ b/one-to-one-sample-app/iOS/SampleApp/OneToOneCommunicator.m
@@ -6,6 +6,8 @@
 //  Copyright © 2016 AgilityFeat. All rights reserved.
 //
 
+#import <Opentok/OpenTok.h>
+
 #import "OneToOneCommunicator.h"
 #import "OTKAnalytics.h"
 
@@ -14,6 +16,7 @@
 @property (nonatomic) NSString *sessionId;
 @property (nonatomic) NSString *token;
 
+@property (nonatomic) BOOL isCallEnabled;
 @property (nonatomic) OTSubscriber *subscriber;
 @property (nonatomic) OTPublisher *publisher;
 @property (nonatomic) OTSession *session;
@@ -27,7 +30,6 @@
 
 - (OTPublisher *)publisher {
     if (!_publisher) {
-        
         NSString *deviceName = [UIDevice currentDevice].name;
         _publisher = [[OTPublisher alloc] initWithDelegate:self name:deviceName];
     }
@@ -86,7 +88,7 @@
             self.session = nil;
         }
         else {
-            NSLog(@"%@", error);
+            self.isCallEnabled = YES;
         }
     }
 }
@@ -97,6 +99,13 @@
         
         OTError *error;
         [self.session disconnect:&error];
+        
+        if (error) {
+            self.session = nil;
+        }
+        else {
+            self.isCallEnabled = NO;
+        }
     }
 }
 
@@ -229,6 +238,55 @@
     NSInteger partner = [apiKey integerValue];
     OTKAnalytics *logging = [[OTKAnalytics alloc] initWithSessionId:sessionId connectionId:self.session.connection.connectionId partnerId:partner clientVersion:@"ios-vsol-1.0.0"];
     [logging logEventAction:@"one-to-one-sample-app" variation:@""];
+}
+
+#pragma mark - Setters and Getters
+- (UIView *)subscriberView {
+    return self.subscriber.view;
+}
+
+- (UIView *)publisherView {
+    return self.publisher.view;
+}
+
+- (void)setSubscribeToAudio:(BOOL)subscribeToAudio {
+    _subscriber.subscribeToAudio = subscribeToAudio;
+}
+
+- (BOOL)subscribeToAudio {
+    return _subscriber.subscribeToAudio;
+}
+
+- (void)setSubscribeToVideo:(BOOL)subscribeToVideo {
+    _subscriber.subscribeToVideo = subscribeToVideo;
+}
+
+- (BOOL)subscribeToVideo {
+    return _subscriber.subscribeToVideo;
+}
+
+- (void)setPublishAudio:(BOOL)publishAudio {
+    _publisher.publishAudio = publishAudio;
+}
+
+- (BOOL)publishAudio {
+    return _publisher.publishAudio;
+}
+
+- (void)setPublishVideo:(BOOL)publishVideo {
+    _publisher.publishVideo = publishVideo;
+}
+
+- (BOOL)publishVideo {
+    return _publisher.publishVideo;
+}
+
+- (AVCaptureDevicePosition)cameraPosition {
+    return _publisher.cameraPosition;
+}
+
+- (void)setCameraPosition:(AVCaptureDevicePosition)cameraPosition {
+    _publisher.cameraPosition = cameraPosition;
 }
 
 @end


### PR DESCRIPTION
***Goal***: 
Try to reduce the confusion from the OpenTok platform SDK

***Approach***:
- hide all the OpenTok logic into the implement files in `oneToOneCommunicator`
- expose developer friendly APIs in `oneToOneCommunicator`

***Benefit***:
- developers can grab the `oneToOneCommunicator` directly and use it
- convenient for us to integrate into other sample apps

@marinaserranomontes @aradiquez, please review and consider give :+1:. We can follow this guide in order to allow contribution.