### PR TITLE
Stop using OTAcceleratorPackUtil in iOS sample

### DIFF
--- a/iOS/README.md
+++ b/iOS/README.md
@@ -20,8 +20,6 @@ Configure the sample app code. Then, build and run the app.
 
 1. Get values for **API Key**, **Session ID**, and **Token**. See [OpenTok One-to-One Communication Sample App home page](../README.md) for important information.
 
-1. In XCode, open **AppDelegate.h** and add [OTAcceleratorPackUtil](https://cocoapods.org/pods/OTAcceleratorPackUtil) by `#import <OTAcceleratorPackUtil/OTAcceleratorPackUtil.h>`
-
 1. Replace the following empty strings with the corresponding **API Key**, **Session ID**, and **Token** values:
 
     ```objc


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I have resolved any merge conflicts. Confirmation: ____

#### This fixes issue #___.

## What's in this pull request?
Stop indicating to add OTAcceleratorPackUtil. Not needed anymore.
>...
